### PR TITLE
reduced comments and changed variable names for method grow

### DIFF
--- a/jhotdraw-utils/src/main/java/org/jhotdraw/geom/Geom.java
+++ b/jhotdraw-utils/src/main/java/org/jhotdraw/geom/Geom.java
@@ -620,30 +620,26 @@ public final class Geom {
   }
 
   /**
-   * Resizes the <code>Rectangle2D.Double</code> both horizontally and vertically.
+   * Resizes the Rectangle2D both horizontally and vertically.
    *
-   * <p>This method modifies the <code>Rectangle2D.Double</code> so that it is <code>h</code> units
-   * larger on both the left and right side, and <code>v</code> units larger at both the top and
+   * <p>This method modifies the Rectangle2D.Double so that it is horizontal expansion units larger
+   * on both the left and right side, and vertical expansion units larger at both the top and
    * bottom.
    *
-   * <p>The new <code>Rectangle2D.Double</code> has (<code>x&nbsp;-&nbsp;h</code>, <code>
-   * y&nbsp;-&nbsp;v</code>) as its top-left corner, a width of <code>width</code>&nbsp;<code>+
-   * </code>&nbsp;<code>2h</code>, and a height of <code>height</code>&nbsp;<code>+</code>&nbsp;
-   * <code>2v</code>.
+   * <p>The new Rectangle2D.Double grows is if HE and VE are positive,
    *
-   * <p>If negative values are supplied for <code>h</code> and <code>v</code>, the size of the
-   * <code>Rectangle2D.Double</code> decreases accordingly. The <code>grow</code> method does not
-   * check whether the resulting values of <code>width</code> and <code>height</code> are
-   * non-negative.
+   * <p>If negative values are supplied for HE and VE, the size of the Rectangle2D decreases
+   * accordingly. The grow() method does not check whether the resulting values of width and height
+   * are non-negative.
    *
-   * @param h the horizontal expansion
-   * @param v the vertical expansion
+   * @param HE the horizontal expansion
+   * @param VE the vertical expansion
    */
-  public static void grow(Rectangle2D.Double r, double h, double v) {
-    r.x -= h;
-    r.y -= v;
-    r.width += h * 2d;
-    r.height += v * 2d;
+  public static void grow(Rectangle2D.Double r, double HE, double VE) {
+    r.x -= HE;
+    r.y -= VE;
+    r.width += HE * 2d;
+    r.height += VE * 2d;
   }
 
   /**

--- a/jhotdraw-utils/src/main/java/org/jhotdraw/geom/Geom.java
+++ b/jhotdraw-utils/src/main/java/org/jhotdraw/geom/Geom.java
@@ -626,20 +626,20 @@ public final class Geom {
    * on both the left and right side, and vertical expansion units larger at both the top and
    * bottom.
    *
-   * <p>The new Rectangle2D.Double grows is if HE and VE are positive,
+   * <p>The new Rectangle2D.Double grows is if hozrintalExpansion and verticalExpansion are positive,
    *
-   * <p>If negative values are supplied for HE and VE, the size of the Rectangle2D decreases
+   * <p>If negative values are supplied for hozrintalExpansion and verticalExpansion, the size of the Rectangle2D decreases
    * accordingly. The grow() method does not check whether the resulting values of width and height
    * are non-negative.
    *
-   * @param HE the horizontal expansion
-   * @param VE the vertical expansion
+   * @param hozrintalExpansion
+   * @param verticalExpansion
    */
-  public static void grow(Rectangle2D.Double r, double HE, double VE) {
-    r.x -= HE;
-    r.y -= VE;
-    r.width += HE * 2d;
-    r.height += VE * 2d;
+  public static void grow(Rectangle2D.Double r, double hozrintalExpansion, double verticalExpansion) {
+    r.x -= hozrintalExpansion;
+    r.y -= verticalExpansion;
+    r.width += hozrintalExpansion * 2d;
+    r.height += verticalExpansion * 2d;
   }
 
   /**


### PR DESCRIPTION
The comment for method grow() was too lengthy so I reduced it. And I changed the variable names v and h to VE and HE to give a clearer abbreviation